### PR TITLE
バグ修正と機能改善

### DIFF
--- a/CommitPMX/CommitPMX/Commit.cs
+++ b/CommitPMX/CommitPMX/Commit.cs
@@ -43,9 +43,7 @@ namespace CommitPMX
 
         public void WriteModel()
         {
-            // 上書き保存
-            Connector.SavePMXFile(Model.FilePath);
-
+            var modelPath = Model.FilePath;
             var commitPath = Path.Combine(DirectoryToCommit, $"{CommitTime:yyyy-MM-dd-HH-mm-ss-ff}_{Regex.Replace(Comment, @"[<>:\/\\|? *""]", "")}");
 
             // フルパスの長さには上限があるので
@@ -54,6 +52,10 @@ namespace CommitPMX
                 commitPath = commitPath.Substring(0, 250);
 
             Connector.SavePMXFile($"{commitPath}.pmx");
+
+            // コミット保存をした時点でModel.FilePathの値が書き換わるのでもとに戻す
+            Model.FilePath = modelPath;
+            Connector.SavePMXFile(Model.FilePath);
         }
     }
 }

--- a/CommitPMX/CommitPMX/Commit.cs
+++ b/CommitPMX/CommitPMX/Commit.cs
@@ -3,6 +3,7 @@ using PEPlugin.Pmx;
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace CommitPMX
 {
@@ -22,7 +23,7 @@ namespace CommitPMX
             CommitTime = DateTime.Now;
 
             var modelPath = model.FilePath;
-            DirectoryToCommit = Path.Combine(Path.GetDirectoryName(modelPath), $"Commit_{Path.GetFileNameWithoutExtension(Model.FilePath)}");
+            DirectoryToCommit = Path.Combine(Path.GetDirectoryName(modelPath), $"CommitLog_{Path.GetFileNameWithoutExtension(Model.FilePath)}");
             Comment = comment;
 
             Directory.CreateDirectory(DirectoryToCommit);
@@ -37,10 +38,7 @@ namespace CommitPMX
         public void WriteLog()
         {
             using (StreamWriter writer = new StreamWriter(Path.Combine(DirectoryToCommit, "CommitLog.csv"), true, Encoding.UTF8))
-            {
-                // ログを書込
-                writer.WriteLine($"{CommitTime:yyyy/MM/dd HH:mm:ss.ff}, {Path.GetFileNameWithoutExtension(Model.FilePath)}, {Comment}");
-            }
+                writer.WriteLine($"\"{CommitTime:yyyy/MM/dd HH:mm:ss.ff}\",\"{Comment.Replace("\"", "\"\"")}\"");
         }
 
         public void WriteModel()
@@ -48,16 +46,14 @@ namespace CommitPMX
             // 上書き保存
             Connector.SavePMXFile(Model.FilePath);
 
-            var modelName = Path.GetFileNameWithoutExtension(Model.FilePath);
-            string commitName = $"{CommitTime:yyyy-MM-dd-HH-mm-ss-ff}-{Comment}";
+            var commitPath = Path.Combine(DirectoryToCommit, $"{CommitTime:yyyy-MM-dd-HH-mm-ss-ff}-{Regex.Replace(Comment, @"[<>:\/\\|? *""]", "")}");
 
             // フルパスの長さには上限があるので
             // 少し余裕を持ったパス名にする
-            if (commitName.Length > 250)
-                commitName = commitName.Substring(0, 250 - modelName.Length);
+            if (commitPath.Length > 250)
+                commitPath = commitPath.Substring(0, 250);
 
-            // コメント付き保存
-            Connector.SavePMXFile(Path.Combine(DirectoryToCommit, $"{modelName}_{commitName}.pmx"));
+            Connector.SavePMXFile($"{commitPath}.pmx");
         }
     }
 }

--- a/CommitPMX/CommitPMX/Commit.cs
+++ b/CommitPMX/CommitPMX/Commit.cs
@@ -46,7 +46,7 @@ namespace CommitPMX
             // 上書き保存
             Connector.SavePMXFile(Model.FilePath);
 
-            var commitPath = Path.Combine(DirectoryToCommit, $"{CommitTime:yyyy-MM-dd-HH-mm-ss-ff}-{Regex.Replace(Comment, @"[<>:\/\\|? *""]", "")}");
+            var commitPath = Path.Combine(DirectoryToCommit, $"{CommitTime:yyyy-MM-dd-HH-mm-ss-ff}_{Regex.Replace(Comment, @"[<>:\/\\|? *""]", "")}");
 
             // フルパスの長さには上限があるので
             // 少し余裕を持ったパス名にする

--- a/CommitPMX/CommitPMX/FormControl.Designer.cs
+++ b/CommitPMX/CommitPMX/FormControl.Designer.cs
@@ -48,6 +48,7 @@ namespace CommitPMX
             this.textBoxCommitComment.Size = new System.Drawing.Size(361, 118);
             this.textBoxCommitComment.TabIndex = 0;
             this.textBoxCommitComment.TextChanged += new System.EventHandler(this.textBoxCommitComment_TextChanged);
+            this.textBoxCommitComment.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxCommitComment_KeyPress);
             // 
             // labelCommitComment
             // 

--- a/CommitPMX/CommitPMX/FormControl.Designer.cs
+++ b/CommitPMX/CommitPMX/FormControl.Designer.cs
@@ -53,13 +53,14 @@ namespace CommitPMX
             // labelCommitComment
             // 
             this.labelCommitComment.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.labelCommitComment, 2);
             this.labelCommitComment.Dock = System.Windows.Forms.DockStyle.Fill;
             this.labelCommitComment.Location = new System.Drawing.Point(4, 0);
             this.labelCommitComment.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelCommitComment.Name = "labelCommitComment";
-            this.labelCommitComment.Size = new System.Drawing.Size(130, 29);
+            this.labelCommitComment.Size = new System.Drawing.Size(361, 29);
             this.labelCommitComment.TabIndex = 1;
-            this.labelCommitComment.Text = "コメント";
+            this.labelCommitComment.Text = $"コメント({COMMENT_LIMIT}文字以内)  Ctrl+Enterでコミット";
             this.labelCommitComment.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // buttonCommit

--- a/CommitPMX/CommitPMX/FormControl.cs
+++ b/CommitPMX/CommitPMX/FormControl.cs
@@ -7,6 +7,9 @@ namespace CommitPMX
 {
     public partial class FormControl : Form
     {
+        // gitのコメントは50文字以内推奨らしいので
+        private readonly int COMMENT_LIMIT = 50;
+
         IPERunArgs Args { get; }
         IPXPmx Pmx { get; set; }
 
@@ -27,9 +30,8 @@ namespace CommitPMX
         {
             buttonCommit.Enabled = !string.IsNullOrEmpty(textBoxCommitComment.Text);
 
-            // パス文字数制限があるのでとりあえずコメントは144文字制限にしておく
-            if (textBoxCommitComment.Text.Length > 144)
-                textBoxCommitComment.Text = textBoxCommitComment.Text.Substring(0, 144);
+            if (textBoxCommitComment.Text.Length > COMMENT_LIMIT)
+                textBoxCommitComment.Text = textBoxCommitComment.Text.Substring(0, COMMENT_LIMIT);
         }
 
         private void checkBoxAmend_CheckedChanged(object sender, EventArgs e)

--- a/CommitPMX/CommitPMX/FormControl.cs
+++ b/CommitPMX/CommitPMX/FormControl.cs
@@ -44,5 +44,11 @@ namespace CommitPMX
             new Commit(Args.Host.Connector.Pmx.GetCurrentState(), Args.Host.Connector.Form, textBoxCommitComment.Text).Invoke();
             textBoxCommitComment.Clear();
         }
+
+        private void textBoxCommitComment_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (buttonCommit.Enabled && e.KeyChar == '\n')
+                buttonCommit_Click(sender, e);
+        }
     }
 }

--- a/CommitPMX/CommitPMX/FormControl.cs
+++ b/CommitPMX/CommitPMX/FormControl.cs
@@ -28,10 +28,14 @@ namespace CommitPMX
 
         private void textBoxCommitComment_TextChanged(object sender, EventArgs e)
         {
-            buttonCommit.Enabled = !string.IsNullOrEmpty(textBoxCommitComment.Text);
+            var selectionTmp = textBoxCommitComment.SelectionStart;
 
+            buttonCommit.Enabled = !string.IsNullOrEmpty(textBoxCommitComment.Text);
+            
             if (textBoxCommitComment.Text.Length > COMMENT_LIMIT)
                 textBoxCommitComment.Text = textBoxCommitComment.Text.Substring(0, COMMENT_LIMIT);
+
+            textBoxCommitComment.SelectionStart = selectionTmp;
         }
 
         private void checkBoxAmend_CheckedChanged(object sender, EventArgs e)

--- a/CommitPMX/CommitPMX/FormControl.cs
+++ b/CommitPMX/CommitPMX/FormControl.cs
@@ -28,6 +28,8 @@ namespace CommitPMX
 
         private void textBoxCommitComment_TextChanged(object sender, EventArgs e)
         {
+            // テキストの内容をプログラム側で操作するとカーソル位置が最初に戻ってしまう
+            // それを戻すためにカーソル位置を保存して最後に戻す処理を行う
             var selectionTmp = textBoxCommitComment.SelectionStart;
 
             buttonCommit.Enabled = !string.IsNullOrEmpty(textBoxCommitComment.Text);


### PR DESCRIPTION
## 修正した不具合
- モデルのパスが変わることでComitフォルダ内に次の保存位置が移動してしまっていた
- コミットコメントにファイル名として使えない文字があった場合ファイルの保存に失敗する
- コミットコメントに `,` が含まれていた場合CSVファイルのフォーマットが崩れる
- コミットの文字数上限に達すると入力位置が先頭に移動する

## 仕様変更
- コミットコメントの最大文字数を50文字に変更
- 保存するコミットログのフォルダ名とファイル名を変更

## 新機能
- テキスト入力欄でCtrl + Enter を押してコミットができるようになった